### PR TITLE
docs: clarify private network CORS ranges

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -33,7 +33,8 @@ class Config:
         "http://127.0.0.1:3000", 
         "http://localhost:3000",
         "http://0.0.0.0:3000",
-        # Allow any IP in local network (192.168.x.x)
+        # Allow any IP in common private network ranges:
+        # 192.168.0.0/16, 10.0.0.0/8, 172.16.0.0/12
         "http://192.168.0.0/16",
         "http://10.0.0.0/8",
         "http://172.16.0.0/12"


### PR DESCRIPTION
## Summary
- clarify CORS_ORIGINS comment to include all private CIDR ranges

## Testing
- `pytest` *(fails: ImportError: cannot import name '_request_ctx_stack' from 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_689594bf2eec8326b399dba259e4210e