### PR TITLE
fix: import datetime in logger

### DIFF
--- a/backend/utils/logger.py
+++ b/backend/utils/logger.py
@@ -2,6 +2,7 @@ import logging
 import logging.handlers
 import os
 import sys
+from datetime import datetime
 from typing import Optional
 
 def setup_logger(name: str, level: Optional[str] = None) -> logging.Logger:


### PR DESCRIPTION
## Summary
- add missing `datetime` import in backend logger utility

## Testing
- `python -m py_compile backend/utils/logger.py`
- `pytest` *(fails: ImportError: cannot import name '_request_ctx_stack' from 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_689594b0efb08326bfd3d767b9908f7f