### PR TITLE
Remove duplicate localhost CORS origin

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -31,7 +31,6 @@ class Config:
     CORS_ORIGINS = [
         "http://localhost:3000",
         "http://127.0.0.1:3000", 
-        "http://localhost:3000",
         "http://0.0.0.0:3000",
         # Allow any IP in local network (192.168.x.x)
         "http://192.168.0.0/16",


### PR DESCRIPTION
## Summary
- remove duplicate `http://localhost:3000` entry from CORS_ORIGINS

## Testing
- `pytest` *(fails: ImportError: cannot import name '_request_ctx_stack' from 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6895949f6a408326a814d55517a92485