### PR TITLE
fix: robust path safety check

### DIFF
--- a/backend/tests/test_security.py
+++ b/backend/tests/test_security.py
@@ -1,0 +1,15 @@
+import os
+import sys
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from utils.security import is_safe_path  # noqa: E402
+
+def test_is_safe_path_detects_prefix_attack():
+    base = "/var/www"
+    unsafe = "/var/wwwmalicious/file.txt"
+    assert not is_safe_path(base, unsafe)
+
+def test_is_safe_path_allows_subdir():
+    base = "/var/www"
+    safe_relative = "subdir/file.txt"
+    assert is_safe_path(base, safe_relative)

--- a/backend/utils/security.py
+++ b/backend/utils/security.py
@@ -165,8 +165,12 @@ def is_safe_path(base_path, path):
         if os.path.isabs(path):
             real_base = os.path.realpath(base_path)
             real_path = os.path.realpath(path)
-            is_safe = real_path.startswith(real_base)
-            return is_safe
+            try:
+                # os.path.commonpath provides proper path boundary checks
+                return os.path.commonpath([real_base, real_path]) == real_base
+            except ValueError:
+                # Raised if paths are on different drives on Windows; treat as unsafe
+                return False
             
         # For relative paths, join with base and check
         full_path = os.path.abspath(os.path.join(base_path, path)).replace('\\', '/')
@@ -174,8 +178,10 @@ def is_safe_path(base_path, path):
         real_full = os.path.realpath(full_path)
         
         # Check if the path is within base directory
-        is_safe = real_full.startswith(real_base)
-        if not is_safe:
+        try:
+            if os.path.commonpath([real_base, real_full]) != real_base:
+                return False
+        except ValueError:
             return False
             
         # Additional permission check


### PR DESCRIPTION
## Summary
- improve path safety verification using `os.path.commonpath` to avoid prefix attacks
- add tests ensuring malicious paths outside base directory are flagged

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895a4f99b448326906fd2c2a3cf95e5