### PR TITLE
feat: add auth token refresh

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -212,6 +212,7 @@ def register_routes(app: Flask) -> None:
                 'authentication': {
                     'POST /api/auth/login': 'User login',
                     'POST /api/auth/logout': 'User logout',
+                    'POST /api/auth/refresh': 'Refresh JWT token',
                     'GET /api/auth/user': 'Get current user',
                     'POST /api/auth/register': 'Register new user',
                     'POST /api/auth/change-password': 'Change password'

--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -100,6 +100,23 @@ def _set_session_data(user: User) -> None:
     if hasattr(user, 'system_uid'):
         session['uid'] = user.system_uid
 
+@auth_bp.route('/api/auth/refresh', methods=['POST'])
+def refresh_token_route():
+    """Refresh JWT token using the current token."""
+    try:
+        token = _extract_token_from_header()
+        if not token:
+            return jsonify({'error': 'Token required'}), 400
+
+        new_token = auth_service.refresh_token(token)
+        if not new_token:
+            return jsonify({'error': 'Invalid or expired token'}), 401
+
+        return jsonify({'token': new_token})
+    except Exception as e:
+        logger.error(f"Token refresh error: {e}")
+        return jsonify({'error': 'Internal server error'}), 500
+
 @auth_bp.route('/api/auth/register', methods=['POST'])
 def register():
     """Register a new user (for development/testing)."""


### PR DESCRIPTION
## Summary
- add backend endpoint to refresh JWT tokens and wire to auth service
- implement frontend token refresh handling with retry interceptor
- document new refresh endpoint in API docs

## Testing
- `pytest` *(fails: ImportError: cannot import name '_request_ctx_stack' from 'flask')*
- `CI=true npm test` *(fails: No tests found, exiting with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_6895a963e94c8326b4e98fdd8e581427