### PR TITLE
Add Swagger documentation and schema generation

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -5,6 +5,8 @@ from typing import Optional
 
 from flask import Flask, jsonify, send_from_directory, request
 from flask_cors import CORS
+from flask_swagger import swagger
+from flask_swagger_ui import get_swaggerui_blueprint
 
 from models.database import db, init_db
 from utils.logger import setup_logger
@@ -201,64 +203,23 @@ def register_routes(app: Flask) -> None:
             'version': '2.0.0'
         })
     
-    @app.route('/api/docs')
-    def api_documentation():
-        """API Documentation endpoint."""
-        return jsonify({
+    @app.route('/api/swagger.json')
+    def swagger_spec():
+        """Generate OpenAPI specification."""
+        swag = swagger(app)
+        swag['info'] = {
             'title': 'Web Control Panel API',
-            'version': '2.0.0',
-            'description': 'Complete API documentation for Web Control Panel',
-            'endpoints': {
-                'authentication': {
-                    'POST /api/auth/login': 'User login',
-                    'POST /api/auth/logout': 'User logout',
-                    'GET /api/auth/user': 'Get current user',
-                    'POST /api/auth/register': 'Register new user',
-                    'POST /api/auth/change-password': 'Change password'
-                },
-                'virtual_hosts': {
-                    'GET /api/virtual-hosts': 'List all virtual hosts',
-                    'POST /api/virtual-hosts': 'Create new virtual host',
-                    'GET /api/virtual-hosts/{id}': 'Get virtual host details',
-                    'PUT /api/virtual-hosts/{id}': 'Update virtual host',
-                    'DELETE /api/virtual-hosts/{id}': 'Delete virtual host'
-                },
-                'dns': {
-                    'GET /api/dns/zones': 'List DNS zones',
-                    'POST /api/dns/zones': 'Create DNS zone',
-                    'GET /api/dns/zones/{id}/records': 'Get DNS records',
-                    'POST /api/dns/zones/{id}/records': 'Create DNS record'
-                },
-                'system': {
-                    'GET /api/system/health': 'Enhanced system health check with scores',
-                    'GET /api/system/metrics': 'System performance metrics',
-                    'GET /api/system/info': 'System information and features',
-                    'GET /api/system/logs': 'System logs (Admin only)',
-                    'GET /api/system/sync-check': 'Database/filesystem sync check (Admin only)',
-                    'POST /api/system/sync-check/fix': 'Auto-fix sync issues (Admin only)',
-                    'GET /api/system/config-validation': 'Validate service configurations (Admin only)',
-                    'GET /api/system/rate-limits': 'View current rate limits',
-                    'POST /api/system/rate-limits/reset': 'Reset rate limits (Admin only)',
-                    'GET /api/system/backup': 'List backups (Admin only)',
-                    'POST /api/system/backup': 'Create full system backup (Admin only)',
-                    'DELETE /api/system/backup/{id}': 'Delete backup (Admin only)',
-                    'POST /api/system/backup/cleanup': 'Cleanup old backups (Admin only)'
-                },
-                'files': {
-                    'GET /api/files': 'List files',
-                    'POST /api/files/upload': 'Upload file',
-                    'DELETE /api/files/{path}': 'Delete file'
-                }
-            },
-            'authentication': {
-                'type': 'Bearer Token',
-                'header': 'Authorization: Bearer <token>'
-            },
-            'rate_limiting': {
-                'default': '100 requests per minute',
-                'login': '5 attempts per 15 minutes'
-            }
-        })
+            'version': '2.0.0'
+        }
+        return jsonify(swag)
+
+    # Swagger UI blueprint
+    swaggerui_bp = get_swaggerui_blueprint(
+        '/api/docs',
+        '/api/swagger.json',
+        config={'app_name': 'Web Control Panel API'}
+    )
+    app.register_blueprint(swaggerui_bp, url_prefix='/api/docs')
 
 def register_error_handlers(app: Flask) -> None:
     """Register error handlers."""

--- a/backend/generate_schema.py
+++ b/backend/generate_schema.py
@@ -1,0 +1,22 @@
+"""Generate Swagger/OpenAPI schema for the backend."""
+import json
+import os
+from app import create_app
+from flask_swagger import swagger
+
+
+def main() -> None:
+    app = create_app()
+    with app.app_context():
+        spec = swagger(app)
+        spec['info'] = {
+            'title': 'Web Control Panel API',
+            'version': '2.0.0'
+        }
+    output_path = os.path.join(os.path.dirname(__file__), 'swagger.json')
+    with open(output_path, 'w') as f:
+        json.dump(spec, f, indent=2)
+
+
+if __name__ == '__main__':
+    main()

--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -56,7 +56,27 @@ def _extract_token_from_header() -> Optional[str]:
 
 @auth_bp.route('/api/auth/login', methods=['POST'])
 def login():
-    """Handle user login."""
+    """Handle user login.
+    ---
+    tags:
+      - auth
+    parameters:
+      - in: body
+        name: credentials
+        schema:
+          type: object
+          required:
+            - username
+            - password
+          properties:
+            username:
+              type: string
+            password:
+              type: string
+    responses:
+      200:
+        description: Login successful
+    """
     try:
         data = request.get_json()
         if not _validate_login_data(data):
@@ -102,7 +122,14 @@ def _set_session_data(user: User) -> None:
 
 @auth_bp.route('/api/auth/register', methods=['POST'])
 def register():
-    """Register a new user (for development/testing)."""
+    """Register a new user (for development/testing).
+    ---
+    tags:
+      - auth
+    responses:
+      201:
+        description: User registered successfully
+    """
     try:
         data = request.get_json()
         if not _validate_register_data(data):
@@ -135,7 +162,14 @@ def _validate_register_data(data: Dict[str, Any]) -> bool:
 
 @auth_bp.route('/api/auth/logout', methods=['POST'])
 def logout():
-    """Handle user logout."""
+    """Handle user logout.
+    ---
+    tags:
+      - auth
+    responses:
+      200:
+        description: Logout successful
+    """
     try:
         session.clear()
         logger.info("User logged out successfully")
@@ -147,7 +181,14 @@ def logout():
 @auth_bp.route('/api/auth/user', methods=['GET'])
 @login_required
 def get_current_user():
-    """Get current authenticated user information."""
+    """Get current authenticated user information.
+    ---
+    tags:
+      - auth
+    responses:
+      200:
+        description: User information
+    """
     try:
         username = session.get('username') or getattr(request, 'current_username', None)
         if not username:

--- a/backend/routes/database.py
+++ b/backend/routes/database.py
@@ -12,6 +12,14 @@ phpmyadmin_service = PhpMyAdminService()
 
 @database_bp.route('/api/databases', methods=['GET'])
 def get_databases():
+    """List databases.
+    ---
+    tags:
+      - database
+    responses:
+      200:
+        description: List of databases
+    """
     try:
         # Get pagination parameters
         page = request.args.get('page', 1, type=int)

--- a/backend/routes/dns.py
+++ b/backend/routes/dns.py
@@ -9,6 +9,14 @@ bind_service = BindService()
 
 @dns_bp.route('/api/dns/zones', methods=['GET'])
 def get_zones():
+    """List DNS zones.
+    ---
+    tags:
+      - dns
+    responses:
+      200:
+        description: List of DNS zones
+    """
     zones = DNSZone.query.all()
     return jsonify([zone.to_dict() for zone in zones])
 

--- a/backend/routes/email.py
+++ b/backend/routes/email.py
@@ -11,7 +11,14 @@ email_service = EmailService()
 @email_bp.route('/api/email/domains', methods=['GET'])
 @token_required
 def get_domains(current_user):
-    """Get all email domains for the current user"""
+    """Get all email domains for the current user.
+    ---
+    tags:
+      - email
+    responses:
+      200:
+        description: List of email domains
+    """
     try:
         # Get user's virtual hosts
         virtual_hosts = VirtualHost.query.filter_by(user_id=current_user.id).all()

--- a/backend/routes/files.py
+++ b/backend/routes/files.py
@@ -17,6 +17,14 @@ def init_file_service():
 @files_bp.route('/list', methods=['GET'])
 @token_required
 def list_directory(current_user):
+    """List directory contents.
+    ---
+    tags:
+      - files
+    responses:
+      200:
+        description: Directory listing
+    """
     try:
         init_file_service()
         path = request.args.get('path', '/')

--- a/backend/routes/roundcube.py
+++ b/backend/routes/roundcube.py
@@ -13,7 +13,14 @@ roundcube_service = RoundcubeService()
 @roundcube_bp.route('/api/roundcube/status', methods=['GET'])
 @token_required
 def get_roundcube_status(current_user):
-    """Get Roundcube installation and configuration status"""
+    """Get Roundcube installation and configuration status.
+    ---
+    tags:
+      - roundcube
+    responses:
+      200:
+        description: Roundcube status
+    """
     try:
         status = roundcube_service.check_roundcube_status()
         return jsonify({

--- a/backend/routes/ssl.py
+++ b/backend/routes/ssl.py
@@ -8,6 +8,14 @@ ssl_service = SSLService()
 
 @ssl_bp.route('/api/ssl/certificates', methods=['GET'])
 def get_certificates():
+    """List SSL certificates.
+    ---
+    tags:
+      - ssl
+    responses:
+      200:
+        description: List of SSL certificates
+    """
     try:
         certificates = SSLCertificate.query.all()
         return jsonify([cert.to_dict() for cert in certificates])

--- a/backend/routes/system.py
+++ b/backend/routes/system.py
@@ -169,6 +169,14 @@ def get_service_status():
 
 @system_bp.route('/api/system/status')
 def get_system_status():
+    """System status information.
+    ---
+    tags:
+      - system
+    responses:
+      200:
+        description: Current system metrics
+    """
     try:
         # Get system load
         load_avg = os.getloadavg() if hasattr(os, 'getloadavg') else [0, 0, 0]

--- a/backend/routes/user.py
+++ b/backend/routes/user.py
@@ -72,7 +72,14 @@ def user_or_admin_required(f):
 @user_bp.route('/api/users', methods=['GET'])
 @admin_required
 def get_users(current_user):
-    """Return only Linux system users (no database users)."""
+    """Return only Linux system users (no database users).
+    ---
+    tags:
+      - user
+    responses:
+      200:
+        description: List of system users
+    """
     # Collect system users (Linux) only
     if UNIX_MODULES_AVAILABLE:
         try:

--- a/backend/routes/virtual_host.py
+++ b/backend/routes/virtual_host.py
@@ -276,6 +276,14 @@ def _auto_fix_virtual_host(virtual_host):
 @virtual_host_bp.route('/api/virtual-hosts', methods=['GET'])
 @token_required
 def get_virtual_hosts(current_user):
+    """List virtual hosts.
+    ---
+    tags:
+      - virtual_host
+    responses:
+      200:
+        description: List of virtual hosts
+    """
     try:
         # Admin/root can see all virtual hosts
         if current_user.is_admin or current_user.role == 'admin' or current_user.username == 'root':

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "start": "react-app-rewired start",
     "start:lan": "REACT_APP_API_URL=http://192.168.1.174:5000 react-app-rewired start",
-    "build": "react-app-rewired build",
+    "build": "python ../backend/generate_schema.py && react-app-rewired build",
     "test": "react-app-rewired test"
   },
   "proxy": "http://localhost:5000",

--- a/requirements.txt
+++ b/requirements.txt
@@ -68,3 +68,5 @@ redis==5.0.1
 # System Monitoring and Task Scheduling
 schedule==1.2.0
 psutil==5.9.5
+flask-swagger==0.2.14
+flask-swagger-ui==4.11.1


### PR DESCRIPTION
## Summary
- integrate Swagger via flask-swagger and swagger-ui
- document API routes with inline OpenAPI annotations
- generate swagger schema during frontend build

## Testing
- `python backend/generate_schema.py` *(fails: ModuleNotFoundError: No module named 'flask_swagger')*
- `pytest` *(fails: ImportError: cannot import name '_request_ctx_stack' from 'flask')*
- `flake8 backend scripts` *(fails: various warnings in scripts and utils)*

------
https://chatgpt.com/codex/tasks/task_e_6895a974a5fc8326805a8e2827f45273