### PR TITLE
Add authorization decorators and tests for resource access

### DIFF
--- a/backend/routes/ssl.py
+++ b/backend/routes/ssl.py
@@ -2,12 +2,14 @@ from flask import Blueprint, request, jsonify
 from models.ssl_certificate import SSLCertificate, SSLCertificateLog, db
 from services.ssl_service import SSLService
 from datetime import datetime
+from utils.auth import permission_required
 
 ssl_bp = Blueprint('ssl', __name__)
 ssl_service = SSLService()
 
 @ssl_bp.route('/api/ssl/certificates', methods=['GET'])
-def get_certificates():
+@permission_required('ssl', 'read')
+def get_certificates(current_user):
     try:
         certificates = SSLCertificate.query.all()
         return jsonify([cert.to_dict() for cert in certificates])
@@ -15,12 +17,14 @@ def get_certificates():
         return jsonify({'error': str(e)}), 500
 
 @ssl_bp.route('/api/ssl/certificates/<int:id>', methods=['GET'])
-def get_certificate(id):
+@permission_required('ssl', 'read')
+def get_certificate(current_user, id):
     certificate = SSLCertificate.query.get_or_404(id)
     return jsonify(certificate.to_dict())
 
 @ssl_bp.route('/api/ssl/certificates', methods=['POST'])
-def create_certificate():
+@permission_required('ssl', 'create')
+def create_certificate(current_user):
     data = request.get_json()
     
     # Validate required fields
@@ -81,7 +85,8 @@ def create_certificate():
         return jsonify({'error': str(e)}), 500
 
 @ssl_bp.route('/api/ssl/certificates/<int:id>/renew', methods=['POST'])
-def renew_certificate(id):
+@permission_required('ssl', 'update')
+def renew_certificate(current_user, id):
     certificate = SSLCertificate.query.get_or_404(id)
     
     try:
@@ -111,7 +116,8 @@ def renew_certificate(id):
         return jsonify({'error': str(e)}), 500
 
 @ssl_bp.route('/api/ssl/certificates/<int:id>', methods=['DELETE'])
-def delete_certificate(id):
+@permission_required('ssl', 'delete')
+def delete_certificate(current_user, id):
     try:
         certificate = SSLCertificate.query.get_or_404(id)
         
@@ -132,6 +138,7 @@ def delete_certificate(id):
         return jsonify({'error': str(e)}), 500
 
 @ssl_bp.route('/api/ssl/certificates/<int:id>/logs', methods=['GET'])
-def get_certificate_logs(id):
+@permission_required('ssl', 'read')
+def get_certificate_logs(current_user, id):
     certificate = SSLCertificate.query.get_or_404(id)
-    return jsonify([log.to_dict() for log in certificate.logs]) 
+    return jsonify([log.to_dict() for log in certificate.logs])

--- a/backend/routes/user.py
+++ b/backend/routes/user.py
@@ -7,7 +7,7 @@ from services.email_service import EmailService
 from services.bind_service import BindService
 from services.linux_user_service import LinuxUserService, UNIX_MODULES_AVAILABLE
 from models.user import User, Role, Permission
-from utils.auth import token_required
+from utils.auth import token_required, admin_required, permission_required
 from functools import wraps
 import os
 import shutil
@@ -28,29 +28,6 @@ ssl_service = SSLService()
 email_service = EmailService()
 bind_service = BindService()
 linux_service = LinuxUserService()
-
-def admin_required(f):
-    @wraps(f)
-    @token_required
-    def decorated_function(current_user, *args, **kwargs):
-        if not current_user or not (current_user.is_admin or current_user.role == 'admin' or current_user.username == 'root'):
-            return jsonify({'error': 'Admin privileges required'}), 403
-        return f(current_user, *args, **kwargs)
-    return decorated_function
-
-def permission_required(resource_type, action):
-    def decorator(f):
-        @wraps(f)
-        @token_required
-        def decorated_function(current_user, *args, **kwargs):
-            domain = request.args.get('domain')
-            
-            if not user_service.check_permission(current_user.id, domain, resource_type, action):
-                return jsonify({'error': 'Permission denied'}), 403
-                
-            return f(current_user, *args, **kwargs)
-        return decorated_function
-    return decorator
 
 def user_or_admin_required(f):
     @wraps(f)

--- a/backend/services/user_service.py
+++ b/backend/services/user_service.py
@@ -492,8 +492,8 @@ class UserService:
             return True
 
         # Check role-based permissions
-        for role in user.roles:
-            for permission in role.permissions:
+        for role in getattr(user, 'roles', []):
+            for permission in getattr(role, 'permissions', []):
                 if permission.resource_type == resource_type and permission.action == action:
                     return True
 
@@ -501,17 +501,14 @@ class UserService:
         if domain:
             domain_perm = DomainPermission.query.filter_by(user_id=user_id, domain=domain).first()
             if domain_perm:
-                # Check specific permission based on resource type
-                if resource_type == 'virtual_host':
-                    return domain_perm.can_manage_vhost
-                elif resource_type == 'dns':
-                    return domain_perm.can_manage_dns
-                elif resource_type == 'ssl':
-                    return domain_perm.can_manage_ssl
-                elif resource_type == 'email':
-                    return domain_perm.can_manage_email
-                elif resource_type == 'database':
-                    return domain_perm.can_manage_database
+                resource_map = {
+                    'virtual_host': domain_perm.can_manage_vhost,
+                    'dns': domain_perm.can_manage_dns,
+                    'ssl': domain_perm.can_manage_ssl,
+                    'email': domain_perm.can_manage_email,
+                    'database': domain_perm.can_manage_database,
+                }
+                return resource_map.get(resource_type, False)
                 
 
         return False

--- a/backend/tests/test_authorization.py
+++ b/backend/tests/test_authorization.py
@@ -1,0 +1,83 @@
+import os
+import sys
+from datetime import datetime, timedelta
+
+import jwt
+import pytest
+import types
+
+# Provide stub for mysql.connector if unavailable
+mysql_module = types.ModuleType("mysql")
+mysql_connector = types.ModuleType("connector")
+mysql_module.connector = mysql_connector
+mysql_connector.Error = Exception
+sys.modules.setdefault("mysql", mysql_module)
+sys.modules.setdefault("mysql.connector", mysql_connector)
+
+# Stub RoundcubeService to avoid external dependency during tests
+roundcube_module = types.ModuleType("services.roundcube_service")
+
+class DummyRoundcubeService:
+    def __init__(self, *args, **kwargs):
+        pass
+
+roundcube_module.RoundcubeService = DummyRoundcubeService
+sys.modules.setdefault("services.roundcube_service", roundcube_module)
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from app import create_app  # noqa: E402
+from config import TestingConfig  # noqa: E402
+from models.database import db  # noqa: E402
+from models.user import User  # noqa: E402
+
+
+@pytest.fixture
+def app():
+    app = create_app(TestingConfig)
+    yield app
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+def _generate_token(app, user_id):
+    payload = {
+        "user_id": user_id,
+        "exp": datetime.utcnow() + timedelta(hours=1),
+    }
+    return jwt.encode(payload, app.config["SECRET_KEY"], algorithm="HS256")
+
+
+def test_dns_requires_auth(client):
+    res = client.get("/api/dns/zones")
+    assert res.status_code == 401
+
+
+def test_database_requires_auth(client):
+    res = client.get("/api/databases")
+    assert res.status_code == 401
+
+
+def test_ssl_requires_auth(client):
+    res = client.get("/api/ssl/certificates")
+    assert res.status_code == 401
+
+
+def test_dns_create_requires_permission(app, client):
+    with app.app_context():
+        user = User(username="testuser", role="user")
+        user.set_password("password")
+        user.roles = []
+        db.session.add(user)
+        db.session.commit()
+        token = _generate_token(app, user.id)
+
+    res = client.post(
+        "/api/dns/zones",
+        json={"domain_name": "example.com"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 403
+


### PR DESCRIPTION
## Summary
- centralize `permission_required` decorator and expand `check_permission` to cover all resources
- secure DNS, database, and SSL routes with permission or admin checks
- add authorization tests ensuring unauthenticated and unauthorized requests are rejected

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest`


------
https://chatgpt.com/codex/tasks/task_e_6895a981016c832694eadab442c5b94f